### PR TITLE
Security: replace xmldom with @xmldom/xmldom to resolve vulnerabilties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@xmldom/xmldom": "~0.8.10",
         "jmespath": "^0.16.0",
         "jsonpath-plus": "^6.0.1",
         "sweetalert": "^2.1.2",
-        "xmldom": "^0.6.0",
         "xpath": "^0.0.32"
       },
       "devDependencies": {
@@ -2258,6 +2258,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -13154,14 +13162,6 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/xpath": {
       "version": "0.0.32",
       "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
@@ -15044,6 +15044,11 @@
         "@typescript-eslint/types": "4.18.0",
         "eslint-visitor-keys": "^2.0.0"
       }
+    },
+    "@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -23242,11 +23247,6 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xpath": {
       "version": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "jmespath": "^0.16.0",
     "jsonpath-plus": "^6.0.1",
     "sweetalert": "^2.1.2",
-    "xmldom": "^0.6.0",
+    "@xmldom/xmldom": "~0.8.10",
     "xpath": "^0.0.32"
   }
 }

--- a/src/value-extractors/value-extractor-xml.ts
+++ b/src/value-extractors/value-extractor-xml.ts
@@ -1,5 +1,5 @@
 import { ValueExtractor } from './value-extractor'
-import { DOMParser } from 'xmldom'
+import { DOMParser } from '@xmldom/xmldom'
 import { select } from 'xpath'
 
 export const valueExtractorXml: ValueExtractor = {


### PR DESCRIPTION
The `xmldom` package used by this plugin is no longer updated and has been superseded by `@xmldom/xmldom`.  Details noted https://www.npmjs.com/package/@xmldom/xmldom

This replacement also resolves open vulnerabilities listed at https://security.snyk.io/package/npm/xmldom which will allow this package to pass security scans performed by enterprise security teams.
