### PR TITLE
fix: update ResponseContextHook.getBody

### DIFF
--- a/src/insomnia/types/response-context.ts
+++ b/src/insomnia/types/response-context.ts
@@ -4,7 +4,7 @@ export type ResponseContext = {
   getStatusMessage(): string
   getBytesRead(): number
   getTime(): number
-  getBody(): Buffer | null
+  getBody(): Buffer | null | Promise<Buffer | null>
   setBody(body: Buffer): void
   getHeader(name: string): string | Array<string> | null
   hasHeader(name: string): boolean

--- a/src/value-sources/value-source-response-body.ts
+++ b/src/value-sources/value-source-response-body.ts
@@ -11,6 +11,7 @@ export const valueSourceResponseBody: ValueSource = {
     _request: RequestHookContext,
     response: ResponseHookContext,
   ): Promise<string | null | undefined> => {
-    return response.response.getBody()?.toString('utf-8') || ''
+    const body = (await response.response.getBody()) || ''
+    return body.toString('utf-8') || ''
   },
 }


### PR DESCRIPTION
Save variable from response Body was broken.

I am unsure if this is the most proper fix, in the latest insomnia versions 11.0.X,
when checked in debugger getBody() is now wrapped Promise, but none of the others in the interface did.

This code should be able to handle both the case where it is a promise, and isn't.
